### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 `.`で始まるディレクトリや`.gitignore` に記載された条件に従って、特定のファイルやディレクトリを除外します。
 Claudeに組み込むことで、Claudeがプロジェクトの構造を素早く確認でき、Claudeが編集すべきファイルを特定するのに役立ちます。
 
+<a href="https://glama.ai/mcp/servers/1igr60piqh"><img width="380" height="200" src="https://glama.ai/mcp/servers/1igr60piqh/badge" alt="Source Tree Server MCP server" /></a>
+
 ## 機能
 
 - 指定されたディレクトリ配下のファイルツリーをJSON形式で取得


### PR DESCRIPTION
This PR adds a badge for the [MCP Source Tree Server](https://glama.ai/mcp/servers/1igr60piqh) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1igr60piqh"><img width="380" height="200" src="https://glama.ai/mcp/servers/1igr60piqh/badge" alt="Source Tree Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.